### PR TITLE
Учёт HTML оформления в getSelectedText

### DIFF
--- a/jquery.copyright.js
+++ b/jquery.copyright.js
@@ -29,13 +29,20 @@
     }
 
     Copyright.prototype.getSelectedText = function() {
-        var text = "";
+        var html = "";
         if (window.getSelection) {
-            text = window.getSelection().toString();
+            var sel = window.getSelection();
+            if (sel.rangeCount) {
+                var container = document.createElement("div");
+                for (var i = 0, len = sel.rangeCount; i < len; ++i) {
+                    container.appendChild(sel.getRangeAt(i).cloneContents());
+                }
+                html = container.innerHTML;
+            }
         } else if (document.selection) {
-            text = document.selection.createRange().text;
+            html = document.selection.createRange().htmlText;
         }
-        return text;
+        return html;
     };
 
     Copyright.prototype.setSelectionRange = function() {


### PR DESCRIPTION
Сейчас абзацы и списки копируются без переносов одной сплошной строкой текста. Патч добавляет поддержку HTML.
